### PR TITLE
Course navigation 

### DIFF
--- a/website/app/controllers/subjects_controller.rb
+++ b/website/app/controllers/subjects_controller.rb
@@ -16,6 +16,10 @@ class SubjectsController < ApplicationController
 		end 
 	end
 
+	def show
+ @subject = Subject.find(params[:id])
+end
+
   private
 
     def subject_params

--- a/website/app/controllers/subjects_controller.rb
+++ b/website/app/controllers/subjects_controller.rb
@@ -17,10 +17,6 @@ class SubjectsController < ApplicationController
 	end
 	
 	def show
-	 @subject = Subject.find(params[:id]) 
-end
-
-	def show
  @subject = Subject.find(params[:id])
 end
 

--- a/website/app/views/school_admins/view_school_subjects.html.erb
+++ b/website/app/views/school_admins/view_school_subjects.html.erb
@@ -38,9 +38,12 @@
           <tr>
             <td><%= subject.name %></td>
             <td><%= subject.code %></td>
+
+             <td><%= link_to 'Show', subject %></td>
           </tr>
         <% end %>
       </tbody>
+      
     </table>
   </div>
 </div>

--- a/website/app/views/subjects/show.html.erb
+++ b/website/app/views/subjects/show.html.erb
@@ -1,14 +1,19 @@
+
 <p id="notice"><%= notice %></p>
+<p> 
 
-<p>
-  <strong>Name:</strong>
-  <%= @subject.name %>
+<strong>Name:</strong>
+<%= @subject.name %>
 </p>
 
 <p>
-  <strong>Code:</strong>
-  <%= @subject.code %>
+<strong>Code:</strong>
+<%= @subject.code %>
 </p>
 
-<%= link_to 'Edit', edit_subject_path(@subject) %> |
-<%= link_to 'Back', subjects_path %>
+<p>
+<strong>School:</strong>
+<%= @subject.school_admin.school %>
+</p>
+
+<%= link_to 'Back', view_school_subjects_school_admins_path %>

--- a/website/test/controllers/subjects_controller_test.rb
+++ b/website/test/controllers/subjects_controller_test.rb
@@ -44,10 +44,11 @@ class SubjectsControllerTest < ActionController::TestCase
     assert_redirected_to add_subject_school_admins_path
   end
 
-  # test "should show subject" do
-  #   get :show, id: @subject
-  #   assert_response :success
-  # end
+   test "should show subject" do
+      @subject = subjects(:one)
+       get :show, id: @subject
+        assert_response :success
+   end
 
   # test "should get edit" do
   #   get :edit, id: @subject


### PR DESCRIPTION
@sohaghareb @AnasAshraf @mohamedoufa @AnasAshraf  @MariamMohamedFawzy 

external documentation : 
a method show was created in the subjects controller that enables the student to view the subject. The name , code and school where the subject is taken are displayed. there's a link that redirects the student back to all the subjects when the back button is pressed.


![new_uml](https://cloud.githubusercontent.com/assets/10845554/6941686/9d675dae-d88a-11e4-9f57-340b8fb10d27.png)

#15  

