### PR TITLE
System admin can view school admin requests

### DIFF
--- a/website/app/admin/school_admin.rb
+++ b/website/app/admin/school_admin.rb
@@ -1,0 +1,13 @@
+ActiveAdmin.register SchoolAdmin do
+ 
+  #Display email , and school of those who request to be school admins and haven't yet been verified.
+  
+index do
+  
+  if current_school_admin.verified== false
+  column :email
+  column :school
+ 
+  end
+  end
+end


### PR DESCRIPTION

![admin](https://cloud.githubusercontent.com/assets/10845554/6996402/07b36c5a-db8f-11e4-8577-ade8dea3fcc3.png)
@sohaghareb @MariamMohamedFawzy  @AnasAshraf @mohamedoufa 

external documentation:
When a new School Admin is created , a check is made . If it's not verified yet the e-mail and school of the School Admin will be viewed in the requests.

#70 